### PR TITLE
Updated sample, added allowed example

### DIFF
--- a/hpa-violation-constraint.yaml
+++ b/hpa-violation-constraint.yaml
@@ -4,8 +4,8 @@ metadata:
   name: hpa-violation
 spec:
   match:
-      kinds:
-        - apiGroups: [""]
-          kinds: ["HorizontalPodAutoscaler"]
+    kinds:
+      - kinds: ["HorizontalPodAutoscaler"]
   parameters:
     maxReplicas: 15
+  enforcementAction: dryrun

--- a/hpa.yaml
+++ b/hpa.yaml
@@ -1,7 +1,7 @@
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: store-autoscale
+  name: store-autoscale-disallowed
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -9,14 +9,15 @@ spec:
     name: store-autoscale
   minReplicas: 1
   maxReplicas: 20
-  metrics:
-  - type: Object
-    object:
-      describedObject:
-        kind: Service
-        name: store-autoscale
-      metric:
-        name: "autoscaling.googleapis.com|gclb-capacity-utilization"
-      target:
-        averageValue: 70
-        type: AverageValue
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: store-autoscale-allowed
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: store-autoscale
+  minReplicas: 1
+  maxReplicas: 5

--- a/k8shpalimit-template.yaml
+++ b/k8shpalimit-template.yaml
@@ -11,16 +11,13 @@ spec:
         # Schema for the `parameters` field
         openAPIV3Schema:
           properties:
-              items:
-                type: object
-                properties:
-                  maxReplicas:
-                    type: integer
+            maxReplicas:
+              type: integer
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8shpalimit
         violation[{"msg": msg}] {
-          input.spec.maxReplicas > input.parameters.maxReplicas
+          input.review.object.spec.maxReplicas > input.parameters.maxReplicas
           msg := sprintf("The replicas requested are greater than %v is allowed", [input.parameters.maxReplicas])
         }


### PR DESCRIPTION
This now works for me, also added an "allowed" example to match the renamed "disallowed" example
```
$ kubectl apply -f k8shpalimit-template.yaml
constrainttemplate.templates.gatekeeper.sh/k8shpalimit created

$ kubectl apply -f hpa-violation-constraint.yaml
k8shpalimit.constraints.gatekeeper.sh/hpa-violation created

$ kubectl get k8shpalimit.constraints.gatekeeper.sh/hpa-violation -o yaml
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: K8sHpaLimit
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"constraints.gatekeeper.sh/v1beta1","kind":"K8sHpaLimit","metadata":{"annotations":{},"name":"hpa-violation"},"spec":{"enforcementAction":"dryrun","match":{"kinds":[{"kinds":["HorizontalPodAutoscaler"]}]},"parameters":{"maxReplicas":15}}}
  creationTimestamp: "2022-07-01T20:27:17Z"
  generation: 1
  name: hpa-violation
  resourceVersion: "34547"
  uid: 84e73827-2735-4aab-b514-8c2ee1db71f3
spec:
  enforcementAction: dryrun
  match:
    kinds:
    - kinds:
      - HorizontalPodAutoscaler
  parameters:
    maxReplicas: 15
status:
  byPod:
  - constraintUID: 84e73827-2735-4aab-b514-8c2ee1db71f3
    enforced: true
    id: gatekeeper-audit-76b65665b7-9lp5s
    observedGeneration: 1
    operations:
    - audit
    - status
  - constraintUID: 84e73827-2735-4aab-b514-8c2ee1db71f3
    enforced: true
    id: gatekeeper-controller-manager-6959c4b578-lfd2l
    observedGeneration: 1
    operations:
    - webhook

$ kubectl apply -f hpa.yaml
horizontalpodautoscaler.autoscaling/store-autoscale-disallowed created
horizontalpodautoscaler.autoscaling/store-autoscale-allowed created

$ kubectl get k8shpalimit.constraints.gatekeeper.sh/hpa-violation -o yaml

apiVersion: constraints.gatekeeper.sh/v1beta1
kind: K8sHpaLimit
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"constraints.gatekeeper.sh/v1beta1","kind":"K8sHpaLimit","metadata":{"annotations":{},"name":"hpa-violation"},"spec":{"enforcementAction":"dryrun","match":{"kinds":[{"kinds":["HorizontalPodAutoscaler"]}]},"parameters":{"maxReplicas":15}}}
  creationTimestamp: "2022-07-01T20:27:17Z"
  generation: 1
  name: hpa-violation
  resourceVersion: "34621"
  uid: 84e73827-2735-4aab-b514-8c2ee1db71f3
spec:
  enforcementAction: dryrun
  match:
    kinds:
    - kinds:
      - HorizontalPodAutoscaler
  parameters:
    maxReplicas: 15
status:
  auditTimestamp: "2022-07-01T20:27:19Z"
  byPod:
  - constraintUID: 84e73827-2735-4aab-b514-8c2ee1db71f3
    enforced: true
    id: gatekeeper-audit-76b65665b7-9lp5s
    observedGeneration: 1
    operations:
    - audit
    - status
  - constraintUID: 84e73827-2735-4aab-b514-8c2ee1db71f3
    enforced: true
    id: gatekeeper-controller-manager-6959c4b578-lfd2l
    observedGeneration: 1
    operations:
    - webhook
  totalViolations: 1
  violations:
  - enforcementAction: dryrun
    kind: HorizontalPodAutoscaler
    message: The replicas requested are greater than 15 is allowed
    name: store-autoscale-disallowed
    namespace: default
```